### PR TITLE
(fix): fix circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,10 @@ version: 2.1
 executors:
   python-3-9-6:
     docker:
-      - image: circleci/python:3.9.6
+      - image: cimg/python:3.9.6
   node-docker:
     docker:
-      - image: circleci/node:17.6.0
+      - image: cimg/node:17.6.0
 
 orbs:
   python: circleci/python@1.5.0


### PR DESCRIPTION
Switch to cimg/python and cimg/node due to circleci/python and circleci/node being deprecated