### PR TITLE
(refactor): change API for risk score calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ risk_model = cvd_risk_scores.FraminghamRiskScore()
 
 # Define our subject, in this case using a dictionary
 subject = {
-  "sex": "female",
+  "gender": "female",
   "age": 61,
   "SBP_nt": 124,
   "SBP_t": 0,
-  "tch": 180,
+  "TotalChol": 180,
   "HDL": 47,
-  "smoking": True,
+  "smoker": True,
   "diabetes": False
 }
 
@@ -43,22 +43,24 @@ data = np.array([list(subject.values())])
 #  ["female", 61, 124, 0, 180, 47, True, False]
 #])
 
-# Define the columns required by the Framingham risk score in the correct order
-# depending on how the data at the previous step was defined
-columns = list(subject.keys())
-
-# Alternatively:
-#columns = ["sex", "age", "SBP_nt", "SBP_t", "tch", "HDL", "smoking", "diabetes"]
-
-# Define the indexes of these columns in the data array
-indexes = list(range(len(data.shape[1]))) # if the specified columns are contiguous in the data array
-
-# Alternatively, you can specify the exact position of each column in case
-# some aren't relevant for computing the chosen risk model
-# indexes = [0, 2, 3, 4, 6, etc..]
+# define a dictionary mapping our own column names to the names
+# expected by the risk score model.
+# if data is either a numpy array or a list of lists,
+# the `columns_map` mapping must present the columns
+# in the correct order so that data can be cast to a pandas DataFrame.
+columns_map = {
+  "gender": "sex",
+  "age": "age",
+  "SBP_nt": "SBP_nt",
+  "SBP_t": "SBP_t",
+  "TotalChol": "tch",
+  "HDL": "HDL",
+  "smoker": "smoking",
+  "diabetes": "diabetes"
+}
 
 # Compute the risk score
-risk_score = risk_model(data=data, columns=columns, indexes=indexes)
+risk_score = risk_model(data=data, columns_map=columns_map)
 ```
 
 ## About
@@ -67,3 +69,8 @@ risk_score = risk_model(data=data, columns=columns, indexes=indexes)
 
 Available risk models:
 * Framingham Risk Score
+
+
+## References
+[1] D'Agostino, Ralph B Sr et al. “General cardiovascular risk profile for use in primary care: 
+the Framingham Heart Study.” Circulation vol. 117,6 (2008): 743-53. doi:10.1161/CIRCULATIONAHA.107.699579

--- a/src/cvd_risk_scores/modules/templates.py
+++ b/src/cvd_risk_scores/modules/templates.py
@@ -41,7 +41,7 @@ class FraminghamSubject(BaseSubject):
         Is diabetic.
     """
     sex : Sex
-    age : Annotated[int, Field(gt=30)]
+    age : Annotated[float, Field(gt=30.0)]
     HDL : float
     tch : float
     SBP_nt : float

--- a/tests/test_risk_models.py
+++ b/tests/test_risk_models.py
@@ -1,5 +1,7 @@
 import numpy as np
+import pandas as pd
 import pytest
+import logging
 
 from src.cvd_risk_scores.modules import FraminghamRiskScore
 
@@ -30,20 +32,66 @@ def male_subject():
     }
 
 @pytest.fixture
-def col_order_idxs():
-    columns = ["sex", "age", "SBP_nt", "SBP_t", "tch", "HDL", "smoking", "diabetes"]
-    return (columns, list(range(len(columns))))
-
-
-@pytest.fixture
-def data_array(male_subject, female_subject):
+def numpy_array(male_subject, female_subject):
     return np.array([list(male_subject.values()), list(female_subject.values())])
 
+@pytest.fixture
+def pandas_df():
+    columns = ['Cov1', 'TotalChol', 'HDL', 'CovX', 'DIABETES', 'Cov2', 'TREATBP', 'SBP_nt', 
+               'SBP_t', 'Cov3', 'gender', 'age', 'smoker', 'Cov4']
+    
+    data = [99, 160, 48, "yes", True, 451, False, 0.0, 146.0, 'no', 'female', 65, False, 0.05]
 
-def test_framingham_risk_score(data_array, col_order_idxs):
+    df = pd.DataFrame(data=[data], columns=columns)
+    return df
+
+@pytest.fixture
+def list_of_lists(male_subject, female_subject):
+    return [list(male_subject.values()), list(female_subject.values())]
+
+@pytest.fixture
+def framingham_col_map1():
+    col_map = {
+        "age": "age",
+        "gender": "sex",
+        "SBP_nt": "SBP_nt",
+        "SBP_t": "SBP_t",
+        "TotalChol": "tch",
+        "HDL": "HDL",
+        "smoker": "smoking",
+        "DIABETES": "diabetes"
+    }
+
+    return col_map
+
+@pytest.fixture
+def framingham_col_map2():
+    col_map = {
+        "sex": "sex",
+        "age": "age",
+        "SBP_nt": "SBP_nt",
+        "SBP_t": "SBP_t",
+        "tch": "tch",
+        "HDL": "HDL",
+        "smoking": "smoking",
+        "diabetes": "diabetes"
+    }
+
+    return col_map
+
+
+def test_framingham_risk_score(numpy_array, pandas_df, list_of_lists, framingham_col_map1, framingham_col_map2):
     frs = FraminghamRiskScore()
-    scores = frs(data_array, 
-                 columns=col_order_idxs[0],
-                 indexes=col_order_idxs[1])
 
-    assert np.allclose(scores, [0.1562, 0.1048], atol=0.0001)
+    with pytest.raises(ValueError) as ve:
+        frs(numpy_array, 
+            columns_map=["sex", "age", "SBP_nt", "SBP_t", "tch", "HDL", "smoking", "diabetes"])
+
+    scores1 = frs(numpy_array, columns_map=framingham_col_map2)
+    assert np.allclose(scores1, [0.1562, 0.1048], atol=0.0001)
+    
+    scores2 = frs(list_of_lists, columns_map=framingham_col_map2)
+    assert np.allclose(scores2, [0.1562, 0.1048], atol=0.0001)
+
+    scores3 = frs(pandas_df, columns_map=framingham_col_map1)
+    assert np.allclose(scores3, [0.2402], atol=0.0001)


### PR DESCRIPTION
API for calculating risk scores is changed. In particular, future implementations of risk scores will require implementing the _compute_single method of the RiskModel class. The forward method applies _compute_single to each subject along the axis=0 (i.e., rows).
Also, users are not required to manually specify indexes of columns anymore. Now, if the data provided by the user is either a numpy array or a list of lists, a cast to pandas DataFrame is executed. Users are required to provide a column mapping dictionary that maps their own columns names to the columns required by the specific risk score model.